### PR TITLE
fix:🐛 use filename in URL instead of mod name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "xxhash-rust",
  "zip",
 ]
@@ -1886,6 +1887,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bytes = "1.10.1"
 thiserror = "2.0.12"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+uuid = { version = "1.16.0", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3.15.0"

--- a/src/download.rs
+++ b/src/download.rs
@@ -93,6 +93,10 @@ impl ModDownloader {
         let response = self.client.get(url).send().await?.error_for_status()?;
         info!("Status code: {}", response.status().as_u16());
 
+        let filename = util::determine_filename(&response)?;
+        let download_path = self.download_dir.join(format!("{}.zip", filename));
+        info!("Destination: {}", download_path.display());
+
         let total_size = response.content_length().unwrap_or(0);
         info!("Total file size: {}", total_size);
 
@@ -103,8 +107,6 @@ impl ModDownloader {
             .progress_chars("#>-"));
 
         let mut stream = response.bytes_stream();
-        let download_path = self.download_dir.join(format!("{}.zip", name));
-        info!("Destination: {}", download_path.display());
 
         let mut hasher = Xxh64::new(0);
         let mut file = fs::File::create(&download_path).await?;
@@ -204,4 +206,43 @@ pub fn sync_hash_file(file_path: &Path) -> Result<String, Error> {
     }
     let hash_str = format!("{:016x}", hasher.digest());
     Ok(hash_str)
+}
+
+mod util {
+    use super::*;
+    use reqwest::{Response, Url};
+    use uuid::Uuid;
+
+    /// Determines the most appropriate filename for a downloaded mod using URL and metadata
+    pub fn determine_filename(response: &Response) -> Result<String, Error> {
+        // Try to extract filename from the URL path.
+        let filename_from_url = extract_filename_from_url(response.url());
+
+        // Try to extract filename from the ETag header.
+        let filename_from_etag = extract_filename_from_etag(response);
+
+        // Choose the best available filename or generate a random one
+        let mod_filename = filename_from_url
+            .or(filename_from_etag)
+            .unwrap_or_else(|| format!("unknown-mod_{}.zip", Uuid::new_v4()));
+
+        Ok(mod_filename)
+    }
+
+    /// Extracts a filename from the last segment of a URL path
+    fn extract_filename_from_url(url: &Url) -> Option<String> {
+        url.path_segments()
+            .and_then(|mut segments| segments.next_back().filter(|&segment| !segment.is_empty()))
+            .map(String::from)
+    }
+
+    /// Creates a filename using the ETag header value, properly formatted with extension
+    fn extract_filename_from_etag(response: &Response) -> Option<String> {
+        response
+            .headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|etag_value| etag_value.to_str().ok())
+            .map(|etag| etag.trim_matches('"').to_string())
+            .map(|etag| format!("{}.zip", etag))
+    }
 }


### PR DESCRIPTION
avoid invalid filename for the filesystem
- add util modules within download.rs to detemine filename
- add `uuid` as dependency to generate final fallback