### PR TITLE
fix:🐛 streamline the online features

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ This project currently targets **Linux** installation. The **Flatpak** version i
 - [Usage](#usage)
   - [list](#list)
   - [show](#show)
-  - [search](#search-query)
-  - [info](#info-mod_name)
   - [install](#install-mod_name)
   - [update](#update)
 - [Motivation](#motivation)
@@ -27,8 +25,6 @@ This project currently targets **Linux** installation. The **Flatpak** version i
 - **Seamless Mod Installation and Management**: Easily install and manage mods directly from the terminal.
 - **Install Mods by Name**: No need for Olympus or a web browser—just type the mod name to install.
 - **Comprehensive Mod Listing**: View all installed mods along with their names and versions at a glance.
-- **Quick Mod Search**: Effortlessly find mods in the Everest online database without the hassle of navigating a browser.
-- **Detailed Mod Information**: Access in-depth details about specific mods, perfect for manual downloads using external tools like `wget` or `aria2c`.
 - **Installed Mod Details**: Easily check the dependencies of your installed mods for better management.
 - **Automatic Update Checks**: Stay up-to-date with available updates for your installed mods, which can be installed automatically while you play—running in the background!
 - **Asynchronous Downloads**: Experience reduced total download times, lower memory usage, and faster checksum verifications for a smoother experience. 
@@ -99,45 +95,6 @@ everest-mod-cli show "Iceline_silentriver"
 #  - Everest v1.4.0.0
 #  - SkinModHelper v0.6.1
 #  - IcelineLoadingAnim v1.0.0
-```
-
-### `search <query>`
-
-Search for mods in the online database using a search query.
-```bash
-everest-mod-cli search "shrimp"
-# Searching for mods matching 'shrimp'...
-# Found 8 matching mods:
-# 
-# ShrimpGlider (version 1.0.0)
-#  - Updated at: 1680913152
-#  - Page: https://gamebanana.com/mods/436804
-#  - Download: https://gamebanana.com/mmdl/962758
-# 
-# Shrimptember2nd (version 1.0.0)
-#  - Updated at: 1730077291
-#  - Page: https://gamebanana.com/mods/521722
-#  - Download: https://gamebanana.com/mmdl/1309084
-# 
-# ShrimpHelper (version 1.2.3)
-#  - Updated at: 1743778527
-#  - Page: https://gamebanana.com/mods/435408
-#  - Download: https://gamebanana.com/mmdl/1414732
-# ...
-```
-
-### `info <mod_name>`
-
-Display detailed information about a specific mod.
-```bash
-everest-mod-cli info "zbs_Crystal"
-# Looking up information for the mod 'zbs_Crystal'...
-# 
-# zbs_Crystal (version 1.2.8)
-#  - Updated at: 1735987004
-#  - Page: https://gamebanana.com/mods/468140
-#  - Download: https://gamebanana.com/mmdl/1356216
-#  - Hashes: c122676ef89c310d
 ```
 
 ### `install <mod_name>`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,30 +15,14 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
-    /// Search for mods
-    Search(SearchArgs),
-    /// Show mod information from the remote mod registry
-    Info(InfoArgs),
-    /// Install a mod
-    Install(InstallArgs),
     /// List installed mods
     List,
     /// Show detailed information about an installed mod
     Show(ShowArgs),
+    /// Install a mod
+    Install(InstallArgs),
     /// Check for updates
     Update(UpdateArgs),
-}
-
-#[derive(Debug, Args)]
-pub struct SearchArgs {
-    /// Search query
-    pub query: String,
-}
-
-#[derive(Debug, Args)]
-pub struct InfoArgs {
-    /// Mod name
-    pub name: String,
 }
 
 #[derive(Debug, Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,39 +65,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mod_registry = ModRegistry::from(mod_registry_data).await?;
 
             match &cli.command {
-                Commands::Search(args) => {
-                    println!("Searching for mods matching '{}'...", args.query);
-                    let results = mod_registry.search(&args.query);
-                    if results.is_empty() {
-                        println!("No mods found matching the query: '{}'", args.query);
-                    } else {
-                        println!("Found {} matching mods:", results.len());
-                        for mod_info in results {
-                            println!("\n{} (version {})", mod_info.name, mod_info.version);
-                            println!(" - Updated at: {}", mod_info.updated_at);
-                            println!(
-                                " - Page: https://gamebanana.com/mods/{}",
-                                mod_info.gamebanana_id
-                            );
-                            println!(" - Download: {}", mod_info.download_url);
-                        }
-                    }
-                }
-                Commands::Info(args) => {
-                    println!("Looking up information for the mod '{}'...", args.name);
-                    if let Some(mod_info) = mod_registry.get_mod_info(&args.name) {
-                        println!("\n{} (version {})", mod_info.name, mod_info.version);
-                        println!(" - Updated at: {}", mod_info.updated_at);
-                        println!(
-                            " - Page: https://gamebanana.com/mods/{}",
-                            mod_info.gamebanana_id
-                        );
-                        println!(" - Download: {}", mod_info.download_url);
-                        println!(" - Hashes: {}", mod_info.checksums.join(", "));
-                    } else {
-                        println!("Mod '{}' not found", args.name);
-                    }
-                }
                 Commands::Install(args) => {
                     println!("Starting installation of the mod '{}'...", args.name);
                     if let Some(mod_info) = mod_registry.get_mod_info(&args.name) {

--- a/src/mod_registry.rs
+++ b/src/mod_registry.rs
@@ -70,15 +70,6 @@ impl ModRegistry {
         Ok(mod_registry)
     }
 
-    /// Search for mods
-    pub fn search(&self, query: &str) -> Vec<&RemoteModInfo> {
-        info!("Searching remote mod registry for mod: {}", query);
-        self.entries
-            .values()
-            .filter(|mod_info| mod_info.name.to_lowercase().contains(&query.to_lowercase()))
-            .collect()
-    }
-
     /// Get mod information
     pub fn get_mod_info(&self, name: &str) -> Option<&RemoteModInfo> {
         info!("Getting remote mod information for mod: {}", name);


### PR DESCRIPTION
DESCRIPTION
Because these two commands frequently access online databases, they may cause trouble for the host.

BREAKING CHANGES
- The `info` and `search` commands no more working

Close #12 