### PR TITLE
fix:🐛 remove obsolete path from Mods directory

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -22,11 +22,18 @@ use crate::{
 /// Update information about the mod
 #[derive(Debug)]
 pub struct AvailableUpdateInfo {
+    /// The Mod name
     pub name: String,
+    /// Current version (from LocalModInfo)
     pub current_version: String,
+    /// Available version (from RemoteModInfo)
     pub available_version: String,
+    /// Download URL of the Mod
     pub url: String,
+    /// xxHashes of the file
     pub hash: Vec<String>,
+    /// Outdated file
+    pub existing_path: PathBuf,
 }
 
 /// Manage mod downloads
@@ -74,6 +81,7 @@ impl ModDownloader {
                     available_version: available_mod.version,
                     url: available_mod.download_url,
                     hash: available_mod.checksums,
+                    existing_path: local_mod.archive_path,
                 });
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     "  Updated {} to version {}",
                                     update.name, update.available_version
                                 );
+                                if update.existing_path.exists() {
+                                    tokio::fs::remove_file(update.existing_path).await?;
+                                }
                             }
                             println!("\nAll updates installed successfully!");
                         } else {


### PR DESCRIPTION
If the downloaded file and the exiting file have different file paths, the exiting file will remain. By adding `exiting_path` information to `AvailableUpdateInfo` we can check the existence of the file after the downloads are finished. Fixed #14