### PR TITLE
feat:✨ renew list_installed_mod function

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -40,4 +40,6 @@ pub enum Error {
     },
     #[error(transparent)]
     Request(#[from] reqwest::Error),
+    #[error("The file is not hashed. It seems developer's fault")]
+    FileIsNotHashed,
 }


### PR DESCRIPTION
### Changes

- now checksum of `LocalModinfo` become `Option<String>`
- removed hashing task from `list_installed_mods`. now it takes only 200ms for 137 mods (about 3.1GB) before it took over 700ms.
- move file realted functions from src/download.rs to src/fileutil.rs
- move local mods related functions from src/download.rs to src/installed_mod.rs
- add new error: FileIsNotHashing
- add `update_mod_hashes` function to set checksums to installed mods

These changes should fix avoid unnecessary hashing. Fixed #20