### PR TITLE
fix:🐛 unnecessary format for download path

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -47,7 +47,7 @@ impl ModDownloader {
         info!("Status code: {}", response.status().as_u16());
 
         let filename = util::determine_filename(&response)?;
-        let download_path = self.download_dir.join(format!("{}.zip", filename));
+        let download_path = self.download_dir.join(filename);
         info!("Destination: {}", download_path.display());
 
         let total_size = response.content_length().unwrap_or(0);


### PR DESCRIPTION
fix `file.zip.zip` issue