### PR TITLE
💥 Remove `search` and `info` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ This project currently targets **Linux** installation. The **Flatpak** version i
 - [Usage](#usage)
   - [list](#list)
   - [show](#show)
-  - [search](#search-query)
-  - [info](#info-mod_name)
   - [install](#install-mod_name)
   - [update](#update)
 - [Motivation](#motivation)
@@ -24,11 +22,9 @@ This project currently targets **Linux** installation. The **Flatpak** version i
 
 ## Features
 
-- **Seamless Mod Installation and Management**: Easily install and manage mods directly from the terminal.
+- **Seamless Mod Management**: Easily manage mods directly from the terminal.
 - **Install Mods by Name**: No need for Olympus or a web browser—just type the mod name to install.
 - **Comprehensive Mod Listing**: View all installed mods along with their names and versions at a glance.
-- **Quick Mod Search**: Effortlessly find mods in the Everest online database without the hassle of navigating a browser.
-- **Detailed Mod Information**: Access in-depth details about specific mods, perfect for manual downloads using external tools like `wget` or `aria2c`.
 - **Installed Mod Details**: Easily check the dependencies of your installed mods for better management.
 - **Automatic Update Checks**: Stay up-to-date with available updates for your installed mods, which can be installed automatically while you play—running in the background!
 - **Asynchronous Downloads**: Experience reduced total download times, lower memory usage, and faster checksum verifications for a smoother experience. 
@@ -99,45 +95,6 @@ everest-mod-cli show "Iceline_silentriver"
 #  - Everest v1.4.0.0
 #  - SkinModHelper v0.6.1
 #  - IcelineLoadingAnim v1.0.0
-```
-
-### `search <query>`
-
-Search for mods in the online database using a search query.
-```bash
-everest-mod-cli search "shrimp"
-# Searching for mods matching 'shrimp'...
-# Found 8 matching mods:
-# 
-# ShrimpGlider (version 1.0.0)
-#  - Updated at: 1680913152
-#  - Page: https://gamebanana.com/mods/436804
-#  - Download: https://gamebanana.com/mmdl/962758
-# 
-# Shrimptember2nd (version 1.0.0)
-#  - Updated at: 1730077291
-#  - Page: https://gamebanana.com/mods/521722
-#  - Download: https://gamebanana.com/mmdl/1309084
-# 
-# ShrimpHelper (version 1.2.3)
-#  - Updated at: 1743778527
-#  - Page: https://gamebanana.com/mods/435408
-#  - Download: https://gamebanana.com/mmdl/1414732
-# ...
-```
-
-### `info <mod_name>`
-
-Display detailed information about a specific mod.
-```bash
-everest-mod-cli info "zbs_Crystal"
-# Looking up information for the mod 'zbs_Crystal'...
-# 
-# zbs_Crystal (version 1.2.8)
-#  - Updated at: 1735987004
-#  - Page: https://gamebanana.com/mods/468140
-#  - Download: https://gamebanana.com/mmdl/1356216
-#  - Hashes: c122676ef89c310d
 ```
 
 ### `install <mod_name>`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,10 +15,6 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
-    /// Search for mods
-    Search(SearchArgs),
-    /// Show mod information from the remote mod registry
-    Info(InfoArgs),
     /// Install a mod
     Install(InstallArgs),
     /// List installed mods
@@ -27,18 +23,6 @@ pub enum Commands {
     Show(ShowArgs),
     /// Check for updates
     Update(UpdateArgs),
-}
-
-#[derive(Debug, Args)]
-pub struct SearchArgs {
-    /// Search query
-    pub query: String,
-}
-
-#[derive(Debug, Args)]
-pub struct InfoArgs {
-    /// Mod name
-    pub name: String,
 }
 
 #[derive(Debug, Args)]

--- a/src/mod_registry.rs
+++ b/src/mod_registry.rs
@@ -70,17 +70,6 @@ impl ModRegistry {
         Ok(mod_registry)
     }
 
-    /// Search for mods
-    pub fn search(&self, query: &str) -> Vec<&RemoteModInfo> {
-        info!("Searching remote mod registry for the mod: {}", query);
-        let query = query.to_lowercase();
-        self.entries
-            .iter()
-            .filter(|(_, mod_info)| mod_info.name.to_lowercase().contains(&query))
-            .map(|(_, mod_info)| mod_info)
-            .collect()
-    }
-
     /// Get mod information
     pub fn get_mod_info(&self, name: &str) -> Option<&RemoteModInfo> {
         info!("Getting remote mod information for the mod: {}", name);


### PR DESCRIPTION
### DESCRIPTION
After much review and consideration,
we decided to remove these two commands
because they were resource intensive and did not meet our original goals.

### BREAKING CHANGES
The `search` and `info` commands will not be available.

### Foot notes
We should bump major version to `1` because of this breaking change.

Closes #12 